### PR TITLE
Keyword status propagation to resource

### DIFF
--- a/sherlock/report/html.py
+++ b/sherlock/report/html.py
@@ -33,14 +33,12 @@ class HtmlResultModel:
 
     @property
     def status(self):
-        status = "pass"
+        status = "label"
         for child in chain(self.keywords, self.children):
-            if child.status == "fail":
-                return "fail"
-            elif child.status == "skip":
-                status = "skip"
-            elif child.status == "label" and status == "pass":
-                status = "label"
+            if child.status in ("skip", "fail"):
+                return child.status
+            if child.status == "pass":
+                status = "pass"
         return status
 
     def fill_keywords(self, model):


### PR DESCRIPTION
Previously resource was marked as "not used" whenever there was at least one keyword that was not used. Now it will be only marked as not used when all keywords are not used - any other status takes precedence. 

Also fixed the bug where resource was marked as 'pass' instead of 'not used' when there was no resources.